### PR TITLE
Add support for CREGFIX into the install process, mention this in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,4 +399,4 @@ Install the CREGFIX patch (the reference ISOs contain it in the extras folder):
 
 https://github.com/mintsuki/cregfix
 
-For technical reasons this patch cannot be pre-installed with the ISO and must be applied manually.
+The patch can be automated by adding it to the `--extra` parameter of the `sysprep.py` script or dropping it into `_EXTRA_CD_FILES_` before sysprep and installation.


### PR DESCRIPTION
CREGFIX now has a method to automate the installation process as long as it's installed into the extras directory prior to sysprep or invoked in the command line to be added to the install media that way.

Because we're basically installing a snapshot of a functional Win9x install, this is easily possible unlike what the README upstream will tell you as of writing this.

Fixes #45 