### PR TITLE
Clear msdos environment (fixes #99)

### DIFF
--- a/sysprep/sysprep.py
+++ b/sysprep/sysprep.py
@@ -179,11 +179,11 @@ def run_regedit(reg_file):
     # regedit is called from *within* msdos.exe.
 
     if platform.system() == 'Windows':
-        subprocess.run([msdos_exe, regedit_exe, '/L:SYSTEM.DAT', '/R:SYSTEM.DAT', reg_file], check=True, stdout=global_stdout)
+        subprocess.run([msdos_exe, '-e', regedit_exe, '/L:SYSTEM.DAT', '/R:SYSTEM.DAT', reg_file], check=True, stdout=global_stdout)
     else:
         reg_file = get_wine_path(reg_file)
         regedit_exe = get_wine_path(regedit_exe)
-        subprocess.run(['wine', msdos_exe, regedit_exe, '/L:SYSTEM.DAT', '/R:SYSTEM.DAT', reg_file], check=True, stdout=global_stdout)
+        subprocess.run(['wine', msdos_exe, '-e', regedit_exe, '/L:SYSTEM.DAT', '/R:SYSTEM.DAT', reg_file], check=True, stdout=global_stdout)
 
 # Copy a file out of a FAT image, does not preserve attributes and datetime
 def image_copy_out(fs: FAT.Dirtable, filename, output):


### PR DESCRIPTION
Since the other way didn't work, now at least the fix for #99 (tested multiple times, since I always get things wrong when building my ISOs :sweat_smile: )