### PR TITLE
qi_cleanup: Remove redundant destination null in hda block

### DIFF
--- a/installer/install.c
+++ b/installer/install.c
@@ -304,7 +304,6 @@ static void qi_cleanup() {
 
     if (qi_wizData.hda != NULL) {
         util_hardDiskArrayDestroy(qi_wizData.hda);
-        qi_wizData.destination = NULL;
         qi_wizData.hda = NULL;
     }
 


### PR DESCRIPTION
In qi_cleanup(), the hda block was setting qi_wizData.destination = NULL in addition to qi_wizData.hda = NULL. destination is already nulled in the preceding block, making this assignment redundant.

Removed the redundant line.