### PR TITLE
fix: Init.sh wasn't downloading termtypes anymore

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -44,6 +44,8 @@ fi;
 # Download and build termtype data
 
 if [ ! -f "termtypes.ti" ]; then
+  echo Downloading termtype data
+  $DOWNLOAD http://catb.org/terminfo/termtypes.ti.gz
   gunzip termtypes.ti.gz
 fi;
 mkdir -p termtypes


### PR DESCRIPTION
Fixing this error when trying to init the project
<img width="533" height="44" alt="image" src="https://github.com/user-attachments/assets/e1165b23-d428-4a70-b46a-684604f10464" />
